### PR TITLE
corrected a typo in recovered paitients card

### DIFF
--- a/src/components/Cards/Cards.jsx
+++ b/src/components/Cards/Cards.jsx
@@ -103,7 +103,7 @@ const Cards = ({
     <
     Typography className = { styles.cardFooter }
     variant = "body2" >
-        Number of active cases of COVID - 19. <
+        Number of recovered patients of COVID - 19. <
         /Typography> < /
     CardContent > <
         /Grid>


### PR DESCRIPTION
issue #3  
corrected the typo. As this card shows the number of recovered patients, so it should be the no. of recovered patients. Have a look
